### PR TITLE
type err lvq

### DIFF
--- a/neurolab/net.py
+++ b/neurolab/net.py
@@ -178,7 +178,7 @@ def newlvq(minmax, cn0, pc):
     layer_out.initf = None
     layer_out.np['b'].fill(0.0)
     layer_out.np['w'].fill(0.0)
-    inx = np.floor(cn0 * pc.cumsum())
+    inx = np.floor(cn0 * pc.cumsum()).astype(int)
     for n, i in enumerate(inx):
         st = 0 if n == 0 else inx[n - 1]
         layer_out.np['w'][n][int(st):int(i)].fill(1.0)


### PR DESCRIPTION
"TypeError: slice indices must be integers or None or have an __index__ method"
This error arose due to the type of elements in _inx_ which was float instead of int.